### PR TITLE
Support for progressive encoding for JPEG files. Fix builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ ext/*.o
 ext/*.class
 ext/*.jar
 ext/Makefile
+ext/*.bundle
 lib/*.so
 *.gem
 *.rbc

--- a/Rakefile
+++ b/Rakefile
@@ -30,6 +30,10 @@ end
 CLEAN.add('ext/*{.o,.so,.log,.class,.jar}', 'ext/Makefile')
 CLOBBER.add('*.gem')
 
+desc 'Build the jar, use JRUBY environment'
+task :jar => "ext/oil.jar" do
+end
+
 desc 'Build the gem and include the java library'
 task :gem => "ext/oil.jar" do
   system "gem build oil.gemspec"

--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -28,4 +28,6 @@ unless have_library('png')
   abort "libpng was not found."
 end
 
+$CFLAGS = "-fPIC -ggdb3 -O0"
+
 create_makefile('oil')

--- a/ext/jpeg.c
+++ b/ext/jpeg.c
@@ -184,6 +184,7 @@ jpeg_init(struct image *image, read_fn_t read, void *ctx, int sig_bytes)
     struct oil_decompress *oil_dinfo;
 
     image->free = jpeg_free;
+    image->icc_marker = NULL;
 
     dinfo = image->data = malloc(sizeof(struct oil_decompress));
     oil_dinfo = (struct oil_decompress *)dinfo;
@@ -287,9 +288,11 @@ jpeg_writer_write(struct writer *writer)
     jpeg_start_compress(cinfo, TRUE);
 
     icc = src->icc_marker;
-    if(icc != NULL)
+    if(icc != NULL) {
         jpeg_write_marker(cinfo, ICC_MARKER, icc->data , 
             icc->original_length);
+
+    }
 
     for (i=0; i<src->height; i++) {
 	if (src->get_scanline(src, buf))

--- a/ext/jpeg.c
+++ b/ext/jpeg.c
@@ -307,7 +307,7 @@ jpeg_writer_write(struct writer *writer)
 
 void
 jpeg_writer_init(struct writer *writer, write_fn_t write_fn, void *ctx,
-		 struct image *src, int progressive)
+		 struct image *src, int progressive, int quality)
 {
     j_compress_ptr cinfo;
     struct oil_compress *oil_cinfo;
@@ -339,8 +339,14 @@ jpeg_writer_init(struct writer *writer, write_fn_t write_fn, void *ctx,
 
     jpeg_set_defaults(cinfo);
 
-    if(progressive) 
+    // The function jpeg_set_quality() shall construct JPEG quantization tables 
+    // for the given quality setting. The quality value ranges from 0..100. 
+    // If "force_baseline" is TRUE, the computed quantization table entries are limited to 1..255 for JPEG baseline compatibility.
+    jpeg_set_quality(cinfo, quality, 1);
+    
+    if(progressive) {
         jpeg_simple_progression(cinfo);
+    }
 
     writer->src = src;
     writer->data = cinfo;

--- a/ext/jpeg.c
+++ b/ext/jpeg.c
@@ -283,7 +283,7 @@ jpeg_writer_write(struct writer *writer)
 
 void
 jpeg_writer_init(struct writer *writer, write_fn_t write_fn, void *ctx,
-		 struct image *src)
+		 struct image *src, int progressive)
 {
     j_compress_ptr cinfo;
     struct oil_compress *oil_cinfo;
@@ -314,6 +314,9 @@ jpeg_writer_init(struct writer *writer, write_fn_t write_fn, void *ctx,
     oil_cinfo->in_buf = malloc(src->width * src->cmp);
 
     jpeg_set_defaults(cinfo);
+
+    if(progressive) 
+        jpeg_simple_progression(cinfo);
 
     writer->src = src;
     writer->data = cinfo;

--- a/ext/oil.c
+++ b/ext/oil.c
@@ -242,7 +242,6 @@ scalex_init(struct image *i, struct image *src, long width, int taps,
     i->height = src->height;
     i->cmp = src->cmp;
     i->free = scalex_free;
-    i->icc_marker = src->icc_marker;
     i->get_scanline = scalex_get_scanline;
 
     b = malloc(sizeof(struct scalex));
@@ -334,7 +333,6 @@ scaley_init(struct image *i, struct image *src, long height, int taps,
     i->cmp = src->cmp;
     i->free = scaley_free;
     i->get_scanline = scaley_get_scanline;
-    i->icc_marker = src->icc_marker;
     i->data = (void *)b;
 }
 
@@ -357,7 +355,6 @@ cubic_init(struct image *i, struct image *src, long width, long height) {
     i->width = width;
     i->height = height;
     i->cmp = src->cmp;
-    i->icc_marker = src->icc_marker;
 }
 
 /* bilinear resizing */
@@ -377,7 +374,6 @@ linear_init(struct image *i, struct image *src, long width, long height) {
     i->width = width;
     i->height = height;
     i->cmp = src->cmp;
-    i->icc_marker = src->icc_marker;
 }
 
 /* point resizing */
@@ -433,7 +429,6 @@ void point_init(struct image *i, struct image *src, long width, long height)
     i->cmp = src->cmp;
     i->free = point_free;
     i->get_scanline = point_get_scanline;
-    i->icc_marker = src->icc_marker;
 
     b = malloc(sizeof(struct point));
     b->src = src;

--- a/ext/oil.c
+++ b/ext/oil.c
@@ -242,6 +242,7 @@ scalex_init(struct image *i, struct image *src, long width, int taps,
     i->height = src->height;
     i->cmp = src->cmp;
     i->free = scalex_free;
+    i->icc_marker = src->icc_marker;
     i->get_scanline = scalex_get_scanline;
 
     b = malloc(sizeof(struct scalex));
@@ -333,6 +334,7 @@ scaley_init(struct image *i, struct image *src, long height, int taps,
     i->cmp = src->cmp;
     i->free = scaley_free;
     i->get_scanline = scaley_get_scanline;
+    i->icc_marker = src->icc_marker;
     i->data = (void *)b;
 }
 
@@ -355,6 +357,7 @@ cubic_init(struct image *i, struct image *src, long width, long height) {
     i->width = width;
     i->height = height;
     i->cmp = src->cmp;
+    i->icc_marker = src->icc_marker;
 }
 
 /* bilinear resizing */
@@ -374,6 +377,7 @@ linear_init(struct image *i, struct image *src, long width, long height) {
     i->width = width;
     i->height = height;
     i->cmp = src->cmp;
+    i->icc_marker = src->icc_marker;
 }
 
 /* point resizing */
@@ -429,6 +433,7 @@ void point_init(struct image *i, struct image *src, long width, long height)
     i->cmp = src->cmp;
     i->free = point_free;
     i->get_scanline = point_get_scanline;
+    i->icc_marker = src->icc_marker;
 
     b = malloc(sizeof(struct point));
     b->src = src;

--- a/ext/oil.h
+++ b/ext/oil.h
@@ -1,4 +1,6 @@
 #include <stddef.h>
+#include <stdio.h>
+#include <jpeglib.h>
 
 /* Callback to read image data.
  *
@@ -54,6 +56,7 @@ struct image {
     int (*get_scanline)(struct image *image, unsigned char *buffer);
     void (*free)(struct image *image);
     void *data;
+    jpeg_saved_marker_ptr icc_marker;
 };
 
 /* This is the base class for image writers.

--- a/ext/oil.h
+++ b/ext/oil.h
@@ -100,7 +100,7 @@ void ppm_writer_init(struct writer *w, write_fn_t write, void *ctx, struct image
 void jpeg_appinit(); // TODO: lazy init. Needs to be threadsafe.
 int jpeg_init(struct image *i, read_fn_t read, void *ctx, int sig_bytes);
 void jpeg_set_scale_denom(struct image *i, int denom);
-void jpeg_writer_init(struct writer *w, write_fn_t write, void *ctx, struct image *src);
+void jpeg_writer_init(struct writer *w, write_fn_t write, void *ctx, struct image *src, int progressive);
 
 int png_init(struct image *i, read_fn_t read, void *ctx, int sig_bytes);
 void png_writer_init(struct writer *w, write_fn_t write, void *ctx, struct image *src);

--- a/ext/oil.h
+++ b/ext/oil.h
@@ -103,7 +103,7 @@ void ppm_writer_init(struct writer *w, write_fn_t write, void *ctx, struct image
 void jpeg_appinit(); // TODO: lazy init. Needs to be threadsafe.
 int jpeg_init(struct image *i, read_fn_t read, void *ctx, int sig_bytes);
 void jpeg_set_scale_denom(struct image *i, int denom);
-void jpeg_writer_init(struct writer *w, write_fn_t write, void *ctx, struct image *src, int progressive);
+void jpeg_writer_init(struct writer *w, write_fn_t write, void *ctx, struct image *src, int progressive, int quality);
 
 int png_init(struct image *i, read_fn_t read, void *ctx, int sig_bytes);
 void png_writer_init(struct writer *w, write_fn_t write, void *ctx, struct image *src);

--- a/ext/oilrb.c
+++ b/ext/oilrb.c
@@ -264,13 +264,13 @@ yield_resize(VALUE _writer)
 
 static void
 init_equivalent_writer(struct writer *writer, enum image_type type,
-		       struct image *src, int progressive)
+		       struct image *src, int progressive, int quality)
 {
     switch (type) {
       case PPM:
         return ppm_writer_init(writer, rb_write_fn, 0, src);
       case JPEG:
-        return jpeg_writer_init(writer, rb_write_fn, 0, src, progressive);
+        return jpeg_writer_init(writer, rb_write_fn, 0, src, progressive, quality);
       case PNG:
         return png_writer_init(writer, rb_write_fn, 0, src);
     }
@@ -278,8 +278,11 @@ init_equivalent_writer(struct writer *writer, enum image_type type,
 
 /*
  *  call-seq:
- *     oil.each(&block) -> self
+ *     oil.each(hash_parameters, &block) -> self
  *
+ *     hash_parameters can have :progressive set to true/false
+ *                              :quality set to 0..100
+
  *  Yields a series of binary strings that make up the resized image data.
  */
 
@@ -291,10 +294,12 @@ oil_each(int argc, VALUE *argv, VALUE self)
     struct thumbdata *thumb;
     int state;
     long w, h;
-    VALUE progressive=Qtrue;
+    VALUE output_params;
+    VALUE progressive;
+    VALUE quality;
 
-    rb_scan_args(argc, argv, "01&", &progressive);
 
+    rb_scan_args(argc, argv, "01&", &output_params);
     Data_Get_Struct(self, struct thumbdata, thumb);
     check_initialized(thumb);
     check_in_progress(thumb);
@@ -313,8 +318,35 @@ oil_each(int argc, VALUE *argv, VALUE self)
     else
 	cubic_init(&scale, thumb->reader, w, h);
 
-    // cast progressive from anything to boolean value 
-    init_equivalent_writer(&writer, thumb->out_type, &scale, RTEST(progressive));
+
+    quality = INT2FIX(75);
+    progressive = Qtrue;
+
+    switch (TYPE(output_params)) {
+        case T_NIL:
+            break;
+        case T_HASH:
+            quality = rb_hash_aref(output_params, ID2SYM(rb_intern("quality")));
+            if(TYPE(quality) == T_NIL)
+                quality = INT2FIX(75);
+            progressive = rb_hash_aref(output_params, ID2SYM(rb_intern("progressive")));
+            if(TYPE(progressive) == T_NIL)
+                progressive = Qtrue;
+
+            break;
+        default: 
+            progressive = RTEST(output_params);
+    }
+
+    //printf("Progressive is %d\n", progressive == Qtrue);
+    //printf("Quality is %d\n", FIX2INT(quality));
+
+    if(FIX2INT(quality) > 100 || FIX2INT(quality) < 0)
+    {
+        rb_raise(rb_eTypeError, "Invalid quality provided");
+    }
+
+    init_equivalent_writer(&writer, thumb->out_type, &scale, RTEST(progressive), FIX2INT(quality));
     rb_protect(yield_resize, (VALUE)&writer, &state);
 
     writer.free(&writer);

--- a/ext/oilrb.c
+++ b/ext/oilrb.c
@@ -180,21 +180,21 @@ oil_scale(int argc, VALUE *argv, VALUE self)
     long w, h;
     int preserve_aspect_i;
 
-    rb_scan_args(argc, argv, "21", &rb_width, &rb_height, &options);
+    rb_scan_args(argc, argv, "2:", &rb_width, &rb_height, &options);
     Data_Get_Struct(self, struct thumbdata, data);
 
     w = FIX2INT(rb_width);
     h = FIX2INT(rb_height);
     preserve_aspect_i = 1;
 
-    if (TYPE(options) == T_HASH) {
-	interp = rb_hash_aref(options, sym_interpolation);
-	if (!NIL_P(interp))
-	    set_interp(data, interp);
+    if (TYPE(options) == T_HASH){
+        interp = rb_hash_aref(options, sym_interpolation);
+        if (!NIL_P(interp))
+            set_interp(data, interp);
 
-	preserve_aspect = rb_hash_aref(options, sym_preserve_aspect_ratio);
-	if (!NIL_P(preserve_aspect) && !RTEST(preserve_aspect))
-	    preserve_aspect_i = 0;
+        preserve_aspect = rb_hash_aref(options, sym_preserve_aspect_ratio);
+        if (!NIL_P(preserve_aspect) && !RTEST(preserve_aspect))
+            preserve_aspect_i = 0;
     }
 
     if (preserve_aspect_i)
@@ -299,7 +299,7 @@ oil_each(int argc, VALUE *argv, VALUE self)
     VALUE quality;
 
 
-    rb_scan_args(argc, argv, "01&", &output_params);
+    rb_scan_args(argc, argv, ":", &output_params);
     Data_Get_Struct(self, struct thumbdata, thumb);
     check_initialized(thumb);
     check_in_progress(thumb);
@@ -334,7 +334,7 @@ oil_each(int argc, VALUE *argv, VALUE self)
                 progressive = Qtrue;
 
             break;
-        default: 
+        default:
             progressive = RTEST(output_params);
     }
 
@@ -354,7 +354,7 @@ oil_each(int argc, VALUE *argv, VALUE self)
 
     thumb->in_progress = 0;
     if (state)
-	rb_jump_tag(state);
+        rb_jump_tag(state);
     return self;
 }
 

--- a/ext/oilrb.c
+++ b/ext/oilrb.c
@@ -104,6 +104,7 @@ allocate(VALUE klass)
 
     self = Data_Make_Struct(klass, struct thumbdata, mark, deallocate, data);
     data->reader = malloc(sizeof(struct image));
+    data->reader->icc_marker = NULL;
     return self;
 }
 
@@ -298,6 +299,9 @@ oil_each(int argc, VALUE *argv, VALUE self)
     check_initialized(thumb);
     check_in_progress(thumb);
     thumb->in_progress = 1;
+
+    // propagate icc marker if available
+    scale.icc_marker = thumb->reader->icc_marker;
 
     w = thumb->out_width;
     h = thumb->out_height;

--- a/ext/png.c
+++ b/ext/png.c
@@ -86,7 +86,7 @@ png_normalize_input(png_structp read_ptr, png_infop read_i_ptr)
     ctype = png_get_color_type(read_ptr, read_i_ptr);
 
     if (ctype == PNG_COLOR_TYPE_GRAY && bit_depth < 8)
-      png_set_gray_1_2_4_to_8(read_ptr);
+      png_set_expand_gray_1_2_4_to_8(read_ptr);
 
     if (bit_depth < 8)
        png_set_packing(read_ptr);

--- a/oil.gemspec
+++ b/oil.gemspec
@@ -1,13 +1,14 @@
 Gem::Specification.new do |s|
-  s.version = '0.0.3'
+  s.version = '0.0.4'
   s.test_files = %w{test/helper.rb test/test_jpeg.rb test/test_png.rb}
-  s.files = %w{Rakefile README.rdoc ext/oil.c ext/oilrb.c ext/png.c ext/ppm.c ext/extconf.rb ext/oil.jar} + s.test_files
+  s.files = %w{Rakefile README.rdoc ext/extconf.rb } + s.test_files +  
+    Dir['ext/*.c'] + Dir['ext/*.h']
   s.name = 'oil'
   s.platform = Gem::Platform::RUBY
   s.require_path = 'ext'
   s.summary = 'Oil resizes JPEG and PNG images.'
   s.description = "#{s.summary} It aims for fast performance and low memory use."
-  s.authors = ['Timothy Elliott']
+  s.authors = ['Timothy Elliott', 'Fotonauts']
   s.extensions << 'ext/extconf.rb'
   s.email = 'tle@holymonkey.com'
   s.homepage = 'http://github.com/ender672/oil'

--- a/oil.gemspec
+++ b/oil.gemspec
@@ -1,5 +1,5 @@
 Gem::Specification.new do |s|
-  s.version = '0.0.5'
+  s.version = '0.0.6'
   s.test_files = %w{test/helper.rb test/test_jpeg.rb test/test_png.rb}
   s.files = %w{Rakefile README.rdoc ext/extconf.rb } + s.test_files +  
     Dir['ext/*.c'] + Dir['ext/*.h']
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.authors = ['Timothy Elliott', 'Fotonauts']
   s.extensions << 'ext/extconf.rb'
   s.email = 'tle@holymonkey.com'
-  s.homepage = 'http://github.com/ender672/oil'
+  s.homepage = 'http://github.com/fotonauts/oil'
   s.has_rdoc = true
   s.extra_rdoc_files = ['README.rdoc']
 end

--- a/oil.gemspec
+++ b/oil.gemspec
@@ -1,5 +1,5 @@
 Gem::Specification.new do |s|
-  s.version = '0.0.4'
+  s.version = '0.0.5'
   s.test_files = %w{test/helper.rb test/test_jpeg.rb test/test_png.rb}
   s.files = %w{Rakefile README.rdoc ext/extconf.rb } + s.test_files +  
     Dir['ext/*.c'] + Dir['ext/*.h']

--- a/oil.gemspec
+++ b/oil.gemspec
@@ -1,13 +1,14 @@
 Gem::Specification.new do |s|
   s.version = '0.0.3'
   s.test_files = %w{test/helper.rb test/test_jpeg.rb test/test_png.rb}
-  s.files = %w{Rakefile README.rdoc ext/oil.c ext/oilrb.c ext/png.c ext/ppm.c ext/extconf.rb ext/oil.jar} + s.test_files
+  s.files = %w{Rakefile README.rdoc ext/extconf.rb } + s.test_files +  
+    Dir['ext/*.c'] + Dir['ext/*.h']
   s.name = 'oil'
   s.platform = Gem::Platform::RUBY
   s.require_path = 'ext'
   s.summary = 'Oil resizes JPEG and PNG images.'
   s.description = "#{s.summary} It aims for fast performance and low memory use."
-  s.authors = ['Timothy Elliott']
+  s.authors = ['Timothy Elliott', 'Fotonauts']
   s.extensions << 'ext/extconf.rb'
   s.email = 'tle@holymonkey.com'
   s.homepage = 'http://github.com/ender672/oil'

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -123,7 +123,7 @@ def resize_string(str, width=nil, height=nil)
   width ||= 100
   height ||= 200
   out = binary_stringio
-  Oil.new(io, width, height).each{ |d| out << d }
+  Oil.new(io, width, height).each(progressive: false){ |d| out << d }
   out.string
 end
 


### PR DESCRIPTION
This commits contains 2 things:
- A fix to make the gem build correctly on Master
- A new progressive support feature on #each(progressive = true) to generate progressive encoded images.
